### PR TITLE
Move setuptools stuff from setup.py to setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,32 @@
+[metadata]
+name = gcp_flowlogs_reader
+version = 0.6.2
+license = Apache
+url = https://github.com/obsrvbl/gcp-flowlogs-reader
+description = Reader for Google Cloud VPC Flow Logs
+long_description =
+    This project provides a convenient interface for accessing
+    VPC Flow Logs stored in Google Cloud's Stackdriver Logging service.
+long_description_content_type = text/x-rst
+author = Cisco Stealthwatch Cloud
+author_email = support@observable.net
+classifiers =
+    Intended Audience :: Developers
+    Intended Audience :: Information Technology
+    Intended Audience :: System Administrators
+    License :: OSI Approved :: Apache Software License
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
+
+[options]
+packages = find:
+python_requires = >=3.6
+install_requires =
+    google-cloud-logging>=1.6.0,<2.0.0
+    google-cloud-resource-manager>=0.28.3
+
+[options.entry_points]
+console_scripts =
+    gcp_flowlogs_reader = gcp_flowlogs_reader.__main__:main

--- a/setup.py
+++ b/setup.py
@@ -1,38 +1,4 @@
-from setuptools import setup, find_packages
+from setuptools import setup
 
-setup(
-    name='gcp_flowlogs_reader',
-    version='0.6.2',
-    license='Apache',
-    url='https://github.com/obsrvbl/gcp-flowlogs-reader',
-    description='Reader for Google Cloud VPC Flow Logs',
-    long_description=(
-        "This project provides a convenient interface for accessing "
-        "VPC Flow Logs stored in Google Cloud's Stackdriver Logging service."
-    ),
-    long_description_content_type='text/x-rst',
-    author='Cisco Stealthwatch Cloud',
-    author_email='support@observable.net',
-    classifiers=[
-        'Intended Audience :: Developers',
-        'Intended Audience :: Information Technology',
-        'Intended Audience :: System Administrators',
-        'License :: OSI Approved :: Apache Software License',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',
-        'Programming Language :: Python :: 3.9',
-    ],
-    entry_points={
-        'console_scripts': [
-            'gcp_flowlogs_reader = gcp_flowlogs_reader.__main__:main',
-        ],
-    },
-    packages=find_packages(exclude=[]),
-    test_suite='tests',
-    install_requires=[
-        'google-cloud-logging>=1.6.0,<2.0.0',
-        'google-cloud-resource-manager>=0.28.3',
-    ],
-    tests_require=[],
-)
+
+setup()


### PR DESCRIPTION
This PR is analogous to [this commit](https://github.com/obsrvbl/flowlogs-reader/pull/41/commits/f4b224b73d8b5e303bd2118e7ae1b2807941872c) from https://github.com/obsrvbl/flowlogs-reader/pull/41.

Changes made, other than the file format:

(1) I did not carry over these lines:
```python
    test_suite='tests',	
    tests_require=[],
```
Those are for running `python setup.py test`, which is deprecated and isn't used in [the CI file](https://github.com/obsrvbl/gcp-flowlogs-reader/blob/da7f8a419e432086f6bbfea134b6596d6b7d3791/.github/workflows/main.yml#L26).

(2) This line:
```python
    packages=find_packages(exclude=[]),
```
should've been this instead:
```python
    packages=find_packages(exclude=['tests']),
```
I did not carry over the `exclude=` part at all, but will write a separate PR that fixes it.