### PR TITLE
Don't install a top-level `tests` package

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,32 @@
+[metadata]
+name = gcp_flowlogs_reader
+version = 0.6.2
+license = Apache
+url = https://github.com/obsrvbl/gcp-flowlogs-reader
+description = Reader for Google Cloud VPC Flow Logs
+long_description =
+    This project provides a convenient interface for accessing
+    VPC Flow Logs stored in Google Cloud's Stackdriver Logging service.
+long_description_content_type = text/x-rst
+author = Cisco Stealthwatch Cloud
+author_email = support@observable.net
+classifiers =
+    Intended Audience :: Developers
+    Intended Audience :: Information Technology
+    Intended Audience :: System Administrators
+    License :: OSI Approved :: Apache Software License
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
+
+[options]
+packages = find:
+python_requires = >=3.6
+install_requires =
+    google-cloud-logging>=1.6.0,<2.0.0
+    google-cloud-resource-manager>=0.28.3
+
+[options.entry_points]
+console_scripts =
+    gcp_flowlogs_reader = gcp_flowlogs_reader.__main__:main

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,6 +27,10 @@ install_requires =
     google-cloud-logging>=1.6.0,<2.0.0
     google-cloud-resource-manager>=0.28.3
 
+[options.packages.find]
+exclude =
+    tests
+
 [options.entry_points]
 console_scripts =
     gcp_flowlogs_reader = gcp_flowlogs_reader.__main__:main

--- a/setup.py
+++ b/setup.py
@@ -1,38 +1,4 @@
-from setuptools import setup, find_packages
+from setuptools import setup
 
-setup(
-    name='gcp_flowlogs_reader',
-    version='0.6.2',
-    license='Apache',
-    url='https://github.com/obsrvbl/gcp-flowlogs-reader',
-    description='Reader for Google Cloud VPC Flow Logs',
-    long_description=(
-        "This project provides a convenient interface for accessing "
-        "VPC Flow Logs stored in Google Cloud's Stackdriver Logging service."
-    ),
-    long_description_content_type='text/x-rst',
-    author='Cisco Stealthwatch Cloud',
-    author_email='support@observable.net',
-    classifiers=[
-        'Intended Audience :: Developers',
-        'Intended Audience :: Information Technology',
-        'Intended Audience :: System Administrators',
-        'License :: OSI Approved :: Apache Software License',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',
-        'Programming Language :: Python :: 3.9',
-    ],
-    entry_points={
-        'console_scripts': [
-            'gcp_flowlogs_reader = gcp_flowlogs_reader.__main__:main',
-        ],
-    },
-    packages=find_packages(exclude=[]),
-    test_suite='tests',
-    install_requires=[
-        'google-cloud-logging>=1.6.0,<2.0.0',
-        'google-cloud-resource-manager>=0.28.3',
-    ],
-    tests_require=[],
-)
+
+setup()


### PR DESCRIPTION
Analogous to https://github.com/obsrvbl/flowlogs-reader/pull/43 and solves the same problem - `pip install gcp-flowlogs-reader` currently installs a package named `tests`.

Depends on https://github.com/obsrvbl/gcp-flowlogs-reader/pull/13.