### PR TITLE
Stop limiting google-cloud-logging to version 1.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,6 @@ You may pass in these keywords as arguments to affect what flows are returned:
 * `end_time` - defaults to now
 * `filters` - defaults the the standard log name
 * `collect_multiple_projects` - defaults to False
-* `logging_client` - a custom `google.cloud.logging.Client` instance
+* `logging_client` - a custom `google.cloud.logging_v2.Client` instance
 * `service_account_json` - the path to a service account JSON credential file
 * `service_account_info` - the service account information parsed from a credential file. See [`from_service_account`](https://google-auth.readthedocs.io/en/latest/reference/google.oauth2.service_account.html#google.oauth2.service_account.Credentials.from_service_account_info) for more information.

--- a/gcp_flowlogs_reader/gcp_flowlogs_reader.py
+++ b/gcp_flowlogs_reader/gcp_flowlogs_reader.py
@@ -229,7 +229,7 @@ class Reader:
                 iterator = self.logging_client.list_entries(
                     filter_=expression,
                     page_size=self.page_size,
-                    projects=[project],  # only collects current project flows
+                    resource_names=[project],  # only collects current project flows
                 )
                 for page in iterator.pages:
                     for flow_entry in page:

--- a/gcp_flowlogs_reader/gcp_flowlogs_reader.py
+++ b/gcp_flowlogs_reader/gcp_flowlogs_reader.py
@@ -229,7 +229,7 @@ class Reader:
                 iterator = self.logging_client.list_entries(
                     filter_=expression,
                     page_size=self.page_size,
-                    resource_names=[project],  # only collects current project flows
+                    resource_names=[project],  # only current project flows
                 )
                 for page in iterator.pages:
                     for flow_entry in page:

--- a/gcp_flowlogs_reader/gcp_flowlogs_reader.py
+++ b/gcp_flowlogs_reader/gcp_flowlogs_reader.py
@@ -226,13 +226,11 @@ class Reader:
 
         for project in self.project_list:
             try:
-                iterator = self.logging_client.list_entries(
+                for flow_entry in self.logging_client.list_entries(
                     filter_=expression,
                     page_size=self.page_size,
                     resource_names=[f'projects/{project}'],  # only current project flows
-                )
-                for page in iterator.pages:
-                    for flow_entry in page:
-                        yield FlowRecord(flow_entry)
+                ):
+                    yield FlowRecord(flow_entry)
             except GoogleAPIError:  # Expected for removed/restricted projects
                 pass

--- a/gcp_flowlogs_reader/gcp_flowlogs_reader.py
+++ b/gcp_flowlogs_reader/gcp_flowlogs_reader.py
@@ -3,7 +3,7 @@ from datetime import datetime, timedelta
 from ipaddress import ip_address
 
 from google.api_core.exceptions import GoogleAPIError
-from google.cloud import logging as gcp_logging, resource_manager
+from google.cloud import logging_v2 as gcp_logging, resource_manager
 from google.oauth2.service_account import Credentials
 
 BASE_LOG_NAME = 'projects/{}/logs/compute.googleapis.com%2Fvpc_flows'

--- a/gcp_flowlogs_reader/gcp_flowlogs_reader.py
+++ b/gcp_flowlogs_reader/gcp_flowlogs_reader.py
@@ -229,7 +229,8 @@ class Reader:
                 for flow_entry in self.logging_client.list_entries(
                     filter_=expression,
                     page_size=self.page_size,
-                    resource_names=[f'projects/{project}'],  # only current project flows
+                    # only collect current project flows:
+                    resource_names=[f'projects/{project}'],
                 ):
                     yield FlowRecord(flow_entry)
             except GoogleAPIError:  # Expected for removed/restricted projects

--- a/gcp_flowlogs_reader/gcp_flowlogs_reader.py
+++ b/gcp_flowlogs_reader/gcp_flowlogs_reader.py
@@ -229,7 +229,7 @@ class Reader:
                 iterator = self.logging_client.list_entries(
                     filter_=expression,
                     page_size=self.page_size,
-                    resource_names=[project],  # only current project flows
+                    resource_names=[f'projects/{project}'],  # only current project flows
                 )
                 for page in iterator.pages:
                     for flow_entry in page:

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,7 +24,7 @@ classifiers =
 packages = find:
 python_requires = >=3.6
 install_requires =
-    google-cloud-logging
+    google-cloud-logging >= 2.0.0
     google-cloud-resource-manager
 
 [options.packages.find]

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,7 +24,7 @@ classifiers =
 packages = find:
 python_requires = >=3.6
 install_requires =
-    google-cloud-logging >= 2.0.0
+    google-cloud-logging >= 2.0
     google-cloud-resource-manager
 
 [options.packages.find]

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,8 +24,8 @@ classifiers =
 packages = find:
 python_requires = >=3.6
 install_requires =
-    google-cloud-logging>=1.6.0,<2.0.0
-    google-cloud-resource-manager>=0.28.3
+    google-cloud-logging
+    google-cloud-resource-manager
 
 [options.packages.find]
 exclude =

--- a/tests/test_gcp_flowlogs_reader.py
+++ b/tests/test_gcp_flowlogs_reader.py
@@ -511,7 +511,11 @@ class ReaderTests(TestCase):
         mock_list_calls = mock_Client.return_value.list_entries.mock_calls
         for proj in project_list:
             self.assertIn(
-                call(filter_=expression, page_size=1000, resource_names=[proj]),
+                call(
+                    filter_=expression,
+                    page_size=1000,
+                    resource_names=[proj],
+                ),
                 mock_list_calls,
             )
 

--- a/tests/test_gcp_flowlogs_reader.py
+++ b/tests/test_gcp_flowlogs_reader.py
@@ -11,8 +11,8 @@ from google.api_core.exceptions import (
     PermissionDenied,
     NotFound,
 )
-from google.cloud.logging import Client
-from google.cloud.logging.entries import StructEntry
+from google.cloud.logging_v2 import Client
+from google.cloud.logging_v2.entries import StructEntry
 from google.oauth2.service_account import Credentials
 
 from gcp_flowlogs_reader.aggregation import aggregated_records

--- a/tests/test_gcp_flowlogs_reader.py
+++ b/tests/test_gcp_flowlogs_reader.py
@@ -396,7 +396,7 @@ class ReaderTests(TestCase):
         mock_Client.return_value.list_entries.assert_called_once_with(
             filter_=expression,
             page_size=1000,
-            resource_names=['yoyodyne-102010'],
+            resource_names=['projects/yoyodyne-102010'],
         )
 
     @patch(
@@ -470,7 +470,7 @@ class ReaderTests(TestCase):
                 call(
                     filter_=expression,
                     page_size=1000,
-                    resource_names=[proj],
+                    resource_names=[f'projects/{proj}'],
                 ),
                 mock_list_calls,
             )

--- a/tests/test_gcp_flowlogs_reader.py
+++ b/tests/test_gcp_flowlogs_reader.py
@@ -428,7 +428,9 @@ class ReaderTests(TestCase):
             'jsonPayload.start_time < "2018-04-03T10:51:33Z"'
         )
         mock_Client.return_value.list_entries.assert_called_once_with(
-            filter_=expression, page_size=1000, projects=['yoyodyne-102010']
+            filter_=expression,
+            page_size=1000,
+            resource_names=['yoyodyne-102010'],
         )
 
     @patch(
@@ -509,7 +511,7 @@ class ReaderTests(TestCase):
         mock_list_calls = mock_Client.return_value.list_entries.mock_calls
         for proj in project_list:
             self.assertIn(
-                call(filter_=expression, page_size=1000, projects=[proj]),
+                call(filter_=expression, page_size=1000, resource_names=[proj]),
                 mock_list_calls,
             )
 

--- a/tests/test_gcp_flowlogs_reader.py
+++ b/tests/test_gcp_flowlogs_reader.py
@@ -371,7 +371,7 @@ class ReaderTests(TestCase):
 
     def test_iteration(self, mock_Client):
         mock_Client.return_value.project = 'yoyodyne-102010'
-        mock_Client.return_value.list_entries.return_value = iter(SAMPLE_ENTRIES[:2])
+        mock_Client.return_value.list_entries.return_value = iter(SAMPLE_ENTRIES[:3])
 
         earlier = datetime(2018, 4, 3, 9, 51, 22)
         later = datetime(2018, 4, 3, 10, 51, 33)
@@ -413,7 +413,7 @@ class ReaderTests(TestCase):
 
         log_client = MagicMock(TestClient)
         log_client.project = 'yoyodyne-102010'
-        log_client.list_entries.return_value = iter(SAMPLE_ENTRIES[:2])
+        log_client.list_entries.return_value = iter(SAMPLE_ENTRIES[:3])
         mock_Client.return_value = log_client
 
         earlier = datetime(2018, 4, 3, 9, 51, 22)
@@ -483,7 +483,7 @@ class ReaderTests(TestCase):
         resource_client.list_projects.side_effect = [GoogleAPIError]
         log_client = MagicMock(TestClient)
         log_client.project = 'yoyodyne-102010'
-        log_client.list_entries.return_value = iter(SAMPLE_ENTRIES[:2])
+        log_client.list_entries.return_value = iter(SAMPLE_ENTRIES[:3])
         mock_Client.return_value = log_client
         earlier = datetime(2018, 4, 3, 9, 51, 22)
         later = datetime(2018, 4, 3, 10, 51, 33)
@@ -512,7 +512,7 @@ class ReaderTests(TestCase):
         log_client.project = 'proj1'
         log_client.list_entries.side_effect = [
             PermissionDenied(''),
-            iter(SAMPLE_ENTRIES[:2]),
+            iter(SAMPLE_ENTRIES[:3]),
             NotFound(''),
         ]
         mock_Client.return_value = log_client
@@ -549,7 +549,7 @@ class ReaderTests(TestCase):
         mock_Credentials.from_service_account_info.return_value = creds
 
         mock_Client.return_value.project = 'yoyodyne-102010'
-        mock_Client.return_value.list_entries.return_value = iter(SAMPLE_ENTRIES[:2])
+        mock_Client.return_value.list_entries.return_value = iter(SAMPLE_ENTRIES[:3])
 
         resource_client = MagicMock()
         mock_project1 = MagicMock(project_id='yoyodyne-102010')
@@ -648,7 +648,7 @@ class MainCLITests(TestCase):
         )
         with patch(patch_path, autospec=True) as mock_Client:
             mock_Client.return_value.project = 'yoyodyne-102010'
-            mock_Client.return_value.list_entries.return_value = iter(SAMPLE_ENTRIES[:2])
+            mock_Client.return_value.list_entries.return_value = iter(SAMPLE_ENTRIES[:3])
             self.reader = Reader()
 
     def test_action_print(self):
@@ -726,7 +726,7 @@ class MainCLITests(TestCase):
         )
         with patch(patch_path, autospec=TestClient) as mock_Client:
             mock_Client.return_value.project = 'yoyodyne-102010'
-            mock_Client.return_value.list_entries.return_value = iter(SAMPLE_ENTRIES[:2])
+            mock_Client.return_value.list_entries.return_value = iter(SAMPLE_ENTRIES[:3])
 
             argv = [
                 '--start-time',
@@ -755,7 +755,7 @@ class MainCLITests(TestCase):
         self, mock_Client, mock_Resource_Manager
     ):
         mock_Client.return_value.project = 'yoyodyne-102010'
-        mock_Client.return_value.list_entries.return_value = iter(SAMPLE_ENTRIES[:2])
+        mock_Client.return_value.list_entries.return_value = iter(SAMPLE_ENTRIES[:3])
         resource_client = MagicMock()
         mock_project1 = MagicMock(project_id='yoyodyne-102010')
         resource_client.list_projects.return_value = [mock_project1]

--- a/tests/test_gcp_flowlogs_reader.py
+++ b/tests/test_gcp_flowlogs_reader.py
@@ -371,7 +371,9 @@ class ReaderTests(TestCase):
 
     def test_iteration(self, mock_Client):
         mock_Client.return_value.project = 'yoyodyne-102010'
-        mock_Client.return_value.list_entries.return_value = iter(SAMPLE_ENTRIES)
+        mock_Client.return_value.list_entries.return_value = iter(
+            SAMPLE_ENTRIES
+        )
 
         earlier = datetime(2018, 4, 3, 9, 51, 22)
         later = datetime(2018, 4, 3, 10, 51, 33)
@@ -549,7 +551,9 @@ class ReaderTests(TestCase):
         mock_Credentials.from_service_account_info.return_value = creds
 
         mock_Client.return_value.project = 'yoyodyne-102010'
-        mock_Client.return_value.list_entries.return_value = iter(SAMPLE_ENTRIES)
+        mock_Client.return_value.list_entries.return_value = iter(
+            SAMPLE_ENTRIES
+        )
 
         resource_client = MagicMock()
         mock_project1 = MagicMock(project_id='yoyodyne-102010')
@@ -648,7 +652,9 @@ class MainCLITests(TestCase):
         )
         with patch(patch_path, autospec=True) as mock_Client:
             mock_Client.return_value.project = 'yoyodyne-102010'
-            mock_Client.return_value.list_entries.return_value = iter(SAMPLE_ENTRIES)
+            mock_Client.return_value.list_entries.return_value = iter(
+                SAMPLE_ENTRIES
+            )
             self.reader = Reader()
 
     def test_action_print(self):
@@ -726,7 +732,9 @@ class MainCLITests(TestCase):
         )
         with patch(patch_path, autospec=TestClient) as mock_Client:
             mock_Client.return_value.project = 'yoyodyne-102010'
-            mock_Client.return_value.list_entries.return_value = iter(SAMPLE_ENTRIES)
+            mock_Client.return_value.list_entries.return_value = iter(
+                SAMPLE_ENTRIES
+            )
 
             argv = [
                 '--start-time',
@@ -755,7 +763,9 @@ class MainCLITests(TestCase):
         self, mock_Client, mock_Resource_Manager
     ):
         mock_Client.return_value.project = 'yoyodyne-102010'
-        mock_Client.return_value.list_entries.return_value = iter(SAMPLE_ENTRIES)
+        mock_Client.return_value.list_entries.return_value = iter(
+            SAMPLE_ENTRIES
+        )
         resource_client = MagicMock()
         mock_project1 = MagicMock(project_id='yoyodyne-102010')
         resource_client.list_projects.return_value = [mock_project1]

--- a/tests/test_gcp_flowlogs_reader.py
+++ b/tests/test_gcp_flowlogs_reader.py
@@ -371,7 +371,7 @@ class ReaderTests(TestCase):
 
     def test_iteration(self, mock_Client):
         mock_Client.return_value.project = 'yoyodyne-102010'
-        mock_Client.return_value.list_entries.return_value = iter(SAMPLE_ENTRIES[:3])
+        mock_Client.return_value.list_entries.return_value = iter(SAMPLE_ENTRIES)
 
         earlier = datetime(2018, 4, 3, 9, 51, 22)
         later = datetime(2018, 4, 3, 10, 51, 33)
@@ -413,7 +413,7 @@ class ReaderTests(TestCase):
 
         log_client = MagicMock(TestClient)
         log_client.project = 'yoyodyne-102010'
-        log_client.list_entries.return_value = iter(SAMPLE_ENTRIES[:3])
+        log_client.list_entries.return_value = iter(SAMPLE_ENTRIES)
         mock_Client.return_value = log_client
 
         earlier = datetime(2018, 4, 3, 9, 51, 22)
@@ -483,7 +483,7 @@ class ReaderTests(TestCase):
         resource_client.list_projects.side_effect = [GoogleAPIError]
         log_client = MagicMock(TestClient)
         log_client.project = 'yoyodyne-102010'
-        log_client.list_entries.return_value = iter(SAMPLE_ENTRIES[:3])
+        log_client.list_entries.return_value = iter(SAMPLE_ENTRIES)
         mock_Client.return_value = log_client
         earlier = datetime(2018, 4, 3, 9, 51, 22)
         later = datetime(2018, 4, 3, 10, 51, 33)
@@ -512,7 +512,7 @@ class ReaderTests(TestCase):
         log_client.project = 'proj1'
         log_client.list_entries.side_effect = [
             PermissionDenied(''),
-            iter(SAMPLE_ENTRIES[:3]),
+            iter(SAMPLE_ENTRIES),
             NotFound(''),
         ]
         mock_Client.return_value = log_client
@@ -549,7 +549,7 @@ class ReaderTests(TestCase):
         mock_Credentials.from_service_account_info.return_value = creds
 
         mock_Client.return_value.project = 'yoyodyne-102010'
-        mock_Client.return_value.list_entries.return_value = iter(SAMPLE_ENTRIES[:3])
+        mock_Client.return_value.list_entries.return_value = iter(SAMPLE_ENTRIES)
 
         resource_client = MagicMock()
         mock_project1 = MagicMock(project_id='yoyodyne-102010')
@@ -648,7 +648,7 @@ class MainCLITests(TestCase):
         )
         with patch(patch_path, autospec=True) as mock_Client:
             mock_Client.return_value.project = 'yoyodyne-102010'
-            mock_Client.return_value.list_entries.return_value = iter(SAMPLE_ENTRIES[:3])
+            mock_Client.return_value.list_entries.return_value = iter(SAMPLE_ENTRIES)
             self.reader = Reader()
 
     def test_action_print(self):
@@ -726,7 +726,7 @@ class MainCLITests(TestCase):
         )
         with patch(patch_path, autospec=TestClient) as mock_Client:
             mock_Client.return_value.project = 'yoyodyne-102010'
-            mock_Client.return_value.list_entries.return_value = iter(SAMPLE_ENTRIES[:3])
+            mock_Client.return_value.list_entries.return_value = iter(SAMPLE_ENTRIES)
 
             argv = [
                 '--start-time',
@@ -755,7 +755,7 @@ class MainCLITests(TestCase):
         self, mock_Client, mock_Resource_Manager
     ):
         mock_Client.return_value.project = 'yoyodyne-102010'
-        mock_Client.return_value.list_entries.return_value = iter(SAMPLE_ENTRIES[:3])
+        mock_Client.return_value.list_entries.return_value = iter(SAMPLE_ENTRIES)
         resource_client = MagicMock()
         mock_project1 = MagicMock(project_id='yoyodyne-102010')
         resource_client.list_projects.return_value = [mock_project1]

--- a/tests/test_gcp_flowlogs_reader.py
+++ b/tests/test_gcp_flowlogs_reader.py
@@ -130,42 +130,6 @@ SAMPLE_PAYLODS = [
 SAMPLE_ENTRIES = [StructEntry(x, None) for x in SAMPLE_PAYLODS]
 
 
-class MockIterator:
-    def __init__(self):
-        self.pages = (
-            [SAMPLE_ENTRIES[0], SAMPLE_ENTRIES[1]],
-            [SAMPLE_ENTRIES[2]],
-        )
-
-    def __iter__(self):
-        return self
-
-    def __next__(self):
-        return ''
-
-
-class MockFailedIterator:
-    def __init__(self):
-        self.pages = self
-
-    def __iter__(self):
-        return self
-
-    def __next__(self):
-        raise PermissionDenied('403 The caller does not have permission')
-
-
-class MockNotFoundIterator:
-    def __init__(self):
-        self.pages = self
-
-    def __iter__(self):
-        return self
-
-    def __next__(self):
-        raise NotFound('404 Project does not exist: project-name')
-
-
 class TestClient(Client):
     _credentials = ''
 
@@ -407,7 +371,7 @@ class ReaderTests(TestCase):
 
     def test_iteration(self, mock_Client):
         mock_Client.return_value.project = 'yoyodyne-102010'
-        mock_Client.return_value.list_entries.return_value = MockIterator()
+        mock_Client.return_value.list_entries.return_value = iter(SAMPLE_ENTRIES[:2])
 
         earlier = datetime(2018, 4, 3, 9, 51, 22)
         later = datetime(2018, 4, 3, 10, 51, 33)
@@ -449,17 +413,7 @@ class ReaderTests(TestCase):
 
         log_client = MagicMock(TestClient)
         log_client.project = 'yoyodyne-102010'
-        proj1_iterator = MockIterator()
-        proj1_iterator.pages = [[SAMPLE_ENTRIES[0]]]
-        proj2_iterator = MockIterator()
-        proj2_iterator.pages = [[SAMPLE_ENTRIES[1]]]
-        proj3_iterator = MockIterator()
-        proj3_iterator.pages = [[SAMPLE_ENTRIES[2]]]
-        log_client.list_entries.side_effect = [
-            proj1_iterator,
-            proj2_iterator,
-            proj3_iterator,
-        ]
+        log_client.list_entries.return_value = iter(SAMPLE_ENTRIES[:2])
         mock_Client.return_value = log_client
 
         earlier = datetime(2018, 4, 3, 9, 51, 22)
@@ -529,7 +483,7 @@ class ReaderTests(TestCase):
         resource_client.list_projects.side_effect = [GoogleAPIError]
         log_client = MagicMock(TestClient)
         log_client.project = 'yoyodyne-102010'
-        log_client.list_entries.return_value = MockIterator()
+        log_client.list_entries.return_value = iter(SAMPLE_ENTRIES[:2])
         mock_Client.return_value = log_client
         earlier = datetime(2018, 4, 3, 9, 51, 22)
         later = datetime(2018, 4, 3, 10, 51, 33)
@@ -557,9 +511,9 @@ class ReaderTests(TestCase):
         log_client = MagicMock(TestClient)
         log_client.project = 'proj1'
         log_client.list_entries.side_effect = [
-            MockFailedIterator(),
-            MockIterator(),
-            MockNotFoundIterator(),
+            PermissionDenied(''),
+            iter(SAMPLE_ENTRIES[:2]),
+            NotFound(''),
         ]
         mock_Client.return_value = log_client
         earlier = datetime(2018, 4, 3, 9, 51, 22)
@@ -595,7 +549,7 @@ class ReaderTests(TestCase):
         mock_Credentials.from_service_account_info.return_value = creds
 
         mock_Client.return_value.project = 'yoyodyne-102010'
-        mock_Client.return_value.list_entries.return_value = MockIterator()
+        mock_Client.return_value.list_entries.return_value = iter(SAMPLE_ENTRIES[:2])
 
         resource_client = MagicMock()
         mock_project1 = MagicMock(project_id='yoyodyne-102010')
@@ -694,7 +648,7 @@ class MainCLITests(TestCase):
         )
         with patch(patch_path, autospec=True) as mock_Client:
             mock_Client.return_value.project = 'yoyodyne-102010'
-            mock_Client.return_value.list_entries.return_value = MockIterator()
+            mock_Client.return_value.list_entries.return_value = iter(SAMPLE_ENTRIES[:2])
             self.reader = Reader()
 
     def test_action_print(self):
@@ -772,7 +726,7 @@ class MainCLITests(TestCase):
         )
         with patch(patch_path, autospec=TestClient) as mock_Client:
             mock_Client.return_value.project = 'yoyodyne-102010'
-            mock_Client.return_value.list_entries.return_value = MockIterator()
+            mock_Client.return_value.list_entries.return_value = iter(SAMPLE_ENTRIES[:2])
 
             argv = [
                 '--start-time',
@@ -801,7 +755,7 @@ class MainCLITests(TestCase):
         self, mock_Client, mock_Resource_Manager
     ):
         mock_Client.return_value.project = 'yoyodyne-102010'
-        mock_Client.return_value.list_entries.return_value = MockIterator()
+        mock_Client.return_value.list_entries.return_value = iter(SAMPLE_ENTRIES[:2])
         resource_client = MagicMock()
         mock_project1 = MagicMock(project_id='yoyodyne-102010')
         resource_client.list_projects.return_value = [mock_project1]


### PR DESCRIPTION
Issue: https://github.com/obsrvbl/devops/issues/6855

That issue mentions [this migration guide](https://googleapis.dev/python/logging/latest/UPGRADING.html), which says:
>`google.cloud.logging` is an alias for `google.cloud.logging_v2`.

That is not true. It's [similar but not an alias](https://github.com/googleapis/python-logging/blob/master/google/cloud/logging/__init__.py). And the difference was enough to break our tests.
