### PR TITLE
Add compressed bytes sent support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -146,6 +146,7 @@ var
 sdist
 develop-eggs
 .installed.cfg
+.python-version
 
 # Installer logs
 pip-log.txt

--- a/README.md
+++ b/README.md
@@ -99,25 +99,26 @@ destination address, destination port, protocol), use the `aggregate` action.
 VPC Flow Logs entry into a Python object with standard types:
 
 ```
-| Attribute     | Type                 | Example                                                                                              |
-|---------------|----------------------|------------------------------------------------------------------------------------------------------|
-| src_ip        | ipaddress.ip_address | ipaddress.ip_address('192.0.2.2')                                                                    |
-| src_port      | int                  | 3389                                                                                                 |
-| dest_ip       | ipaddress.ip_address | ipaddress.ip_address('198.51.100.1')                                                                 |
-| dest_port     | int                  | 49152                                                                                                |
-| protocol      | int                  | 6                                                                                                    |
-| start_time    | datetime.datetime    | datetime.datetime(2018, 4, 4, 11, 55, 12, 943517)                                                    |
-| end_time      | datetime.datetime    | datetime.datetime(2018, 4, 4, 11, 55, 14, 125304)                                                    |
-| bytes_sent    | int                  | 4446                                                                                                 |
-| packets_sent  | int                  | 13                                                                                                   |
-| rtt_msec      | int                  | 233                                                                                                  |
-| reporter      | str                  | 'SRC'                                                                                                |
-| src_instance  | namedtuple           | InstanceDetails(project_id='yoyodyne-1020', vm_name='vm-1020', region='us-west1', zone='us-west1-a') |
-| dest_instance | namedtuple           | InstanceDetails(project_id='yoyodyne-1020', vm_name='vm-1020', region='us-west1', zone='us-west1-a') |
-| src_vpc       | namedtuple           | VpcDetails(project_id='yoyo-1020', vpc_name='prod-vpc-3', subnetwork_name='prod-net-3')              |
-| dest_vpc      | namedtuple           | VpcDetails(project_id='yoyo-1020', vpc_name='prod-vpc-3', subnetwork_name='prod-net-3')              |
-| src_location  | namedtuple           | GeographicDetails(continent='America', country='usa', region='California', city='Santa Teresa')      |
-| dest_location | namedtuple           | GeographicDetails(continent='America', country='usa', region='California', city='Santa Teresa')      |
+| Attribute             | Type                 | Example                                                                                              |
+|-----------------------|----------------------|------------------------------------------------------------------------------------------------------|
+| src_ip                | ipaddress.ip_address | ipaddress.ip_address('192.0.2.2')                                                                    |
+| src_port              | int                  | 3389                                                                                                 |
+| dest_ip               | ipaddress.ip_address | ipaddress.ip_address('198.51.100.1')                                                                 |
+| dest_port             | int                  | 49152                                                                                                |
+| protocol              | int                  | 6                                                                                                    |
+| start_time            | datetime.datetime    | datetime.datetime(2018, 4, 4, 11, 55, 12, 943517)                                                    |
+| end_time              | datetime.datetime    | datetime.datetime(2018, 4, 4, 11, 55, 14, 125304)                                                    |
+| bytes_sent            | int                  | 4446                                                                                                 |
+| compressed_bytes_sent | int                  | 1234                                                                                                 |
+| packets_sent          | int                  | 13                                                                                                   |
+| rtt_msec              | int                  | 233                                                                                                  |
+| reporter              | str                  | 'SRC'                                                                                                |
+| src_instance          | namedtuple           | InstanceDetails(project_id='yoyodyne-1020', vm_name='vm-1020', region='us-west1', zone='us-west1-a') |
+| dest_instance         | namedtuple           | InstanceDetails(project_id='yoyodyne-1020', vm_name='vm-1020', region='us-west1', zone='us-west1-a') |
+| src_vpc               | namedtuple           | VpcDetails(project_id='yoyo-1020', vpc_name='prod-vpc-3', subnetwork_name='prod-net-3')              |
+| dest_vpc              | namedtuple           | VpcDetails(project_id='yoyo-1020', vpc_name='prod-vpc-3', subnetwork_name='prod-net-3')              |
+| src_location          | namedtuple           | GeographicDetails(continent='America', country='usa', region='California', city='Santa Teresa')      |
+| dest_location         | namedtuple           | GeographicDetails(continent='America', country='usa', region='California', city='Santa Teresa')      |
 ```
 
 `gcp_flowlogs_reader.Reader` acts as an iterator over flows from the logs:

--- a/gcp_flowlogs_reader/__main__.py
+++ b/gcp_flowlogs_reader/__main__.py
@@ -18,6 +18,7 @@ def print_header():
         'start_time',
         'end_time',
         'bytes_sent',
+        'compressed_bytes_sent',
         'packets_sent',
         sep='\t',
     )
@@ -33,6 +34,7 @@ def print_record(record):
         record.start_time.strftime('%Y-%m-%dT%H:%M:%S'),
         record.end_time.strftime('%Y-%m-%dT%H:%M:%S'),
         record.bytes_sent,
+        record.compressed_bytes_sent,
         record.packets_sent,
         sep='\t',
     )

--- a/gcp_flowlogs_reader/aggregation.py
+++ b/gcp_flowlogs_reader/aggregation.py
@@ -2,7 +2,13 @@ from collections import defaultdict, namedtuple
 from datetime import datetime
 
 KEY_FIELDS = ['src_ip', 'dest_ip', 'src_port', 'dest_port', 'protocol']
-VALUE_FIELDS = ['packets_sent', 'bytes_sent', 'start_time', 'end_time']
+VALUE_FIELDS = [
+    'packets_sent',
+    'bytes_sent',
+    'compressed_bytes_sent',
+    'start_time',
+    'end_time',
+]
 
 
 class _FlowStats:
@@ -13,6 +19,7 @@ class _FlowStats:
         self.end_time = datetime.min
         self.packets_sent = 0
         self.bytes_sent = 0
+        self.compressed_bytes_sent = 0
 
     def update(self, flow_record):
         if flow_record.start_time < self.start_time:
@@ -21,6 +28,7 @@ class _FlowStats:
             self.end_time = flow_record.end_time
         self.packets_sent += flow_record.packets_sent
         self.bytes_sent += flow_record.bytes_sent
+        self.compressed_bytes_sent += flow_record.compressed_bytes_sent
 
     def to_dict(self):
         return {x: getattr(self, x) for x in self.__slots__}

--- a/gcp_flowlogs_reader/gcp_flowlogs_reader.py
+++ b/gcp_flowlogs_reader/gcp_flowlogs_reader.py
@@ -71,6 +71,7 @@ class FlowRecord:
     start_time: datetime
     end_time: datetime
     bytes_sent: int
+    compressed_bytes_sent: int
     packets_sent: int
     rtt_msec: Optional[int]
     reporter: str
@@ -99,6 +100,7 @@ class FlowRecord:
         )
 
         self.bytes_sent = int(flow_payload['bytes_sent'])
+        self.compressed_bytes_sent = int(flow_payload['compressed_bytes_sent'])
         self.packets_sent = int(flow_payload['packets_sent'])
 
         rtt_msec = flow_payload.get('rtt_msec')
@@ -150,7 +152,7 @@ class FlowRecord:
         )
 
     def __str__(self):
-        return ', '.join(f'{x}: {getattr(self, x)}' for x in self.__slots__[:9])
+        return ', '.join(f'{x}: {getattr(self, x)}' for x in self.__slots__[:10])
 
     def to_dict(self):
         nt_types = (InstanceDetails, VpcDetails, GeographicDetails)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = gcp_flowlogs_reader
-version = 0.8.0
+version = 0.8.1
 license = Apache
 url = https://github.com/obsrvbl/gcp-flowlogs-reader
 description = Reader for Google Cloud VPC Flow Logs

--- a/tests/test_gcp_flowlogs_reader.py
+++ b/tests/test_gcp_flowlogs_reader.py
@@ -28,6 +28,7 @@ PREFIX = 'gcp_flowlogs_reader.gcp_flowlogs_reader.{}'.format
 SAMPLE_PAYLOADS = [
     {
         'bytes_sent': '491',
+        'compressed_bytes_sent': '123',
         'connection': {
             'dest_ip': '192.0.2.2',
             'dest_port': 3389.0,
@@ -60,6 +61,7 @@ SAMPLE_PAYLOADS = [
     },
     {
         'bytes_sent': '756',
+        'compressed_bytes_sent': '100',
         'connection': {
             'dest_ip': '198.51.100.75',
             'dest_port': 49444.0,
@@ -91,6 +93,7 @@ SAMPLE_PAYLOADS = [
     },
     {
         'bytes_sent': '1020',
+        'compressed_bytes_sent': '100',
         'connection': {
             'dest_ip': '192.0.2.3',
             'dest_port': 65535.0,
@@ -127,6 +130,7 @@ SAMPLE_PAYLOADS = [
     },
     {
         'bytes_sent': '1020',
+        'compressed_bytes_sent': '80',
         'connection': {
             'dest_ip': '192.0.2.3',
             'protocol': 1.0,
@@ -216,6 +220,7 @@ class FlowRecordTests(TestCase):
             ('start_time', datetime(2018, 4, 3, 13, 47, 37)),
             ('end_time', datetime(2018, 4, 3, 13, 47, 38)),
             ('bytes_sent', 491),
+            ('compressed_bytes_sent', 123),
             ('packets_sent', 4),
             ('rtt_msec', 61),
             ('reporter', 'DEST'),
@@ -242,6 +247,7 @@ class FlowRecordTests(TestCase):
             ('start_time', datetime(2018, 4, 3, 13, 47, 32)),
             ('end_time', datetime(2018, 4, 3, 13, 47, 33)),
             ('bytes_sent', 756),
+            ('compressed_bytes_sent', 100),
             ('packets_sent', 6),
             ('rtt_msec', None),
             ('reporter', 'SRC'),
@@ -290,6 +296,7 @@ class FlowRecordTests(TestCase):
             'start_time: 2018-04-03 13:47:37, '
             'end_time: 2018-04-03 13:47:38, '
             'bytes_sent: 491, '
+            'compressed_bytes_sent: 123, '
             'packets_sent: 4'
         )
         self.assertEqual(actual, expected)
@@ -305,6 +312,7 @@ class FlowRecordTests(TestCase):
             ('start_time', datetime(2018, 4, 3, 13, 47, 37)),
             ('end_time', datetime(2018, 4, 3, 13, 47, 38)),
             ('bytes_sent', 491),
+            ('compressed_bytes_sent', 123),
             ('packets_sent', 4),
             ('rtt_msec', 61),
             ('reporter', 'DEST'),
@@ -634,7 +642,8 @@ class AggregationTests(TestCase):
                     49444,
                     6,
                     12,  # Packets doubled
-                    1512,  # Bytes doubled
+                    1512,  # Bytes doubled,
+                    200,
                     datetime(2018, 4, 2, 13, 47, 32),  # Earliest start
                     datetime(2018, 4, 4, 13, 47, 33),  # Latest finish
                 ),
@@ -655,6 +664,7 @@ class AggregationTests(TestCase):
                     6,
                     26,
                     1776,
+                    200,
                     datetime(2018, 4, 3, 13, 47, 31),
                     datetime(2018, 4, 3, 13, 48, 33),
                 ),
@@ -663,6 +673,7 @@ class AggregationTests(TestCase):
                     6,
                     4,
                     491,
+                    123,
                     datetime(2018, 4, 3, 13, 47, 37),
                     datetime(2018, 4, 3, 13, 47, 38),
                 ),
@@ -671,6 +682,7 @@ class AggregationTests(TestCase):
                     1,
                     20,
                     1020,
+                    80,
                     datetime(2018, 4, 3, 13, 48, 33),
                     datetime(2018, 4, 3, 13, 48, 33),
                 ),
@@ -692,15 +704,15 @@ class MainCLITests(TestCase):
         self.assertEqual(
             output.getvalue(),
             'src_ip\tdest_ip\tsrc_port\tdest_port\tprotocol\t'
-            'start_time\tend_time\tbytes_sent\tpackets_sent\n'
+            'start_time\tend_time\tbytes_sent\tcompressed_bytes_sent\tpackets_sent\n'
             '198.51.100.75\t192.0.2.2\t49444\t3389\t6\t2018-04-03T13:47:37\t'
-            '2018-04-03T13:47:38\t491\t4\n'
+            '2018-04-03T13:47:38\t491\t123\t4\n'
             '192.0.2.2\t198.51.100.75\t3389\t49444\t6\t2018-04-03T13:47:32\t'
-            '2018-04-03T13:47:33\t756\t6\n'
+            '2018-04-03T13:47:33\t756\t100\t6\n'
             '192.0.2.2\t192.0.2.3\t3389\t65535\t6\t2018-04-03T13:47:31\t'
-            '2018-04-03T13:48:33\t1020\t20\n'
+            '2018-04-03T13:48:33\t1020\t100\t20\n'
             '192.0.2.2\t192.0.2.3\t0\t0\t1\t2018-04-03T13:48:33\t'
-            '2018-04-03T13:48:33\t1020\t20\n',
+            '2018-04-03T13:48:33\t1020\t80\t20\n',
         )
 
     def test_action_print_limit(self):
@@ -709,9 +721,9 @@ class MainCLITests(TestCase):
         self.assertEqual(
             output.getvalue(),
             'src_ip\tdest_ip\tsrc_port\tdest_port\tprotocol\t'
-            'start_time\tend_time\tbytes_sent\tpackets_sent\n'
+            'start_time\tend_time\tbytes_sent\tcompressed_bytes_sent\tpackets_sent\n'
             '198.51.100.75\t192.0.2.2\t49444\t3389\t6\t2018-04-03T13:47:37\t'
-            '2018-04-03T13:47:38\t491\t4\n',
+            '2018-04-03T13:47:38\t491\t123\t4\n',
         )
 
     def test_action_print_error(self):
@@ -729,11 +741,11 @@ class MainCLITests(TestCase):
         self.assertEqual(
             output.getvalue(),
             'src_ip\tdest_ip\tsrc_port\tdest_port\tprotocol\t'
-            'start_time\tend_time\tbytes_sent\tpackets_sent\n'
+            'start_time\tend_time\tbytes_sent\tcompressed_bytes_sent\tpackets_sent\n'
             '192.0.2.2\t192.0.2.3\t3389\t65535\t6\t2018-04-03T13:47:31\t'
-            '2018-04-03T13:48:33\t1020\t20\n'
+            '2018-04-03T13:48:33\t1020\t100\t20\n'
             '192.0.2.2\t192.0.2.3\t0\t0\t1\t2018-04-03T13:48:33\t'
-            '2018-04-03T13:48:33\t1020\t20\n',
+            '2018-04-03T13:48:33\t1020\t80\t20\n',
         )
 
     def test_action_aggregate(self):


### PR DESCRIPTION
This adds a `compressed_bytes_sent` field to compliment `bytes_sent` for users that want to track both.