### PR TITLE
Retry for rate limit in 3.0.0 similar to pre3.0.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}

--- a/gcp_flowlogs_reader/gcp_flowlogs_reader.py
+++ b/gcp_flowlogs_reader/gcp_flowlogs_reader.py
@@ -4,22 +4,15 @@ from time import sleep
 from typing import NamedTuple, Optional, Union
 
 from google.api_core.exceptions import (
-    DeadlineExceeded,
     Forbidden,
     GoogleAPIError,
-    InternalServerError,
     NotFound,
-    ServiceUnavailable,
     TooManyRequests,
 )
-from google.api_core.retry import Retry, if_exception_type
 from google.cloud.logging import (
     Client as LoggingClient,
     __version__ as gcp_logging_version,
 )
-from google.cloud.logging_v2 import _gapic
-from google.cloud.logging_v2.types import ListLogEntriesRequest
-from google.cloud.logging_v2.types import LogEntry
 
 try:
     from google.cloud.logging import StructEntry
@@ -34,23 +27,37 @@ from google.oauth2.service_account import Credentials
 
 BASE_LOG_NAME = 'projects/{}/logs/compute.googleapis.com%2Fvpc_flows'
 
-# Custom retry that includes TooManyRequests (429) in addition to the
-# default transient errors.  Applied per-page by the gapic pager so
-# each individual page fetch is retried with exponential backoff.
-DEFAULT_RETRY = Retry(
-    initial=1.0,
-    maximum=60.0,
-    multiplier=2.0,
-    predicate=if_exception_type(
-        TooManyRequests,
-        DeadlineExceeded,
-    ),
-    deadline=300.0,
-)
+
+def _extract_page_token(iterator):
+    """Extract the current page token from a v3 list_entries generator.
+
+    Reaches into generator frame locals to read the page token from the
+    underlying pager. Supports both gRPC and HTTP transport paths.
+    """
+    try:
+        frame = iterator.gi_frame
+        if frame is None:
+            return None
+        locals_ = frame.f_locals
+
+        # gRPC path: log_entries_pager(log_iter)
+        if 'log_iter' in locals_:
+            inner_frame = locals_['log_iter'].gi_frame
+            if inner_frame is not None:
+                pager = inner_frame.f_locals.get('self')
+                if pager is not None:
+                    return pager._response.next_page_token or None
+
+        # HTTP path: _entries_pager(page_iter)
+        if 'page_iter' in locals_:
+            return locals_['page_iter'].next_page_token
+    except (AttributeError, KeyError):
+        pass
+
+    return None
 
 
 def page_helper(logging_client, wait_time=1.0, **kwargs):
-    print(f"Fetching with filter: {kwargs.get('filter_')}")
     # handle google-cloud-logging >= 3.0
     if gcp_logging_version[0] == '3':
         # the project arg in google-cloud-logging >= 3.0 was changed to resource_names
@@ -60,33 +67,19 @@ def page_helper(logging_client, wait_time=1.0, **kwargs):
             ]
             del kwargs['projects']
 
-        # Use the low-level gapic client so we can pass a custom Retry
-        # that handles 429s. The pager manages page_token automatically.
-        gapic_client = logging_client.logging_api._gapic_api
+        kwargs['page_token'] = None
+        while True:
+            try:
+                entry_num = 0
+                iterator = logging_client.list_entries(**kwargs)
+                for entry in iterator:
+                    token = _extract_page_token(iterator)
+                    kwargs['page_token'] = token
+                    yield entry
+                break
+            except TooManyRequests:
+                sleep(wait_time)
 
-        request = ListLogEntriesRequest(
-            resource_names=kwargs.get('resource_names', []),
-            filter=kwargs.get('filter_', ''),
-            order_by='timestamp asc',
-            page_size=kwargs.get('page_size', 0),
-        )
-
-        # The gapic pager applies retry to every page fetch (including the
-        # first).  On rate-limit (429) it backs off automatically.
-        pager = gapic_client.list_log_entries(
-            request=request,
-            retry=DEFAULT_RETRY,
-            timeout=DEFAULT_RETRY.deadline,
-        )
-
-        # Parse gapic LogEntry protos back into high-level StructEntry
-        # objects via the same bridge the high-level Client uses.
-        loggers = {}
-        for entry in pager:
-            log_entry_dict = _gapic._parse_log_entry(LogEntry.pb(entry))
-            yield _gapic.entry_from_resource(
-                log_entry_dict, logging_client, loggers=loggers
-            )
         return
 
     # google-cloud-logging < 3.0 requires us to handle paging
@@ -252,7 +245,7 @@ class Reader:
         logging_client=None,
         service_account_json=None,
         service_account_info=None,
-        page_size=1000,
+        page_size=2,
         wait_time=1.0,
         **kwargs,
     ):

--- a/gcp_flowlogs_reader/gcp_flowlogs_reader.py
+++ b/gcp_flowlogs_reader/gcp_flowlogs_reader.py
@@ -1,7 +1,5 @@
 from datetime import datetime, timedelta
 from ipaddress import ip_address, IPv4Address, IPv6Address
-import json
-from collections import OrderedDict
 from time import sleep
 from typing import NamedTuple, Optional, Union
 
@@ -28,40 +26,9 @@ except ImportError:
 from google.oauth2.service_account import Credentials
 
 BASE_LOG_NAME = 'projects/{}/logs/compute.googleapis.com%2Fvpc_flows'
-DEFAULT_DEDUPE_CACHE_SIZE = 100000
 
 
-def _entry_dedupe_key(entry):
-    payload = getattr(entry, 'payload', None)
-    if isinstance(payload, dict):
-        payload_repr = json.dumps(payload, sort_keys=True, default=str)
-    else:
-        payload_repr = str(payload)
-
-    log_name = getattr(entry, 'log_name', None)
-
-    return (
-        'payload_log_name',
-        payload_repr,
-        str(log_name),
-    )
-
-
-def _remember_seen(dedupe_cache, dedupe_key, max_dedupe_keys):
-    if dedupe_key in dedupe_cache:
-        dedupe_cache.move_to_end(dedupe_key)
-        return True
-
-    dedupe_cache[dedupe_key] = None
-    if len(dedupe_cache) > max_dedupe_keys:
-        dedupe_cache.popitem(last=False)
-    return False
-
-
-def page_helper(logging_client, wait_time=1.0, max_dedupe_keys=None, **kwargs):
-    max_dedupe_keys = max_dedupe_keys or DEFAULT_DEDUPE_CACHE_SIZE
-    dedupe_cache = OrderedDict()
-
+def page_helper(logging_client, wait_time=1.0, **kwargs):
     # handle google-cloud-logging >= 3.0
     if gcp_logging_version[0] == '3':
         # the project arg in google-cloud-logging >= 3.0 was changed to resource_names
@@ -71,14 +38,17 @@ def page_helper(logging_client, wait_time=1.0, max_dedupe_keys=None, **kwargs):
             ]
             del kwargs['projects']
         # google-cloud-logging >= 3.0 handles paging internally
+        yielded_count = 0
         while True:
             try:
                 iterator = logging_client.list_entries(**kwargs)
+                skip = yielded_count
                 for entry in iterator:
-                    dedupe_key = _entry_dedupe_key(entry)
-                    if _remember_seen(dedupe_cache, dedupe_key, max_dedupe_keys):
+                    if skip > 0:
+                        skip -= 1
                         continue
                     yield entry
+                    yielded_count += 1
                 return
             except TooManyRequests:
                 sleep(wait_time)

--- a/gcp_flowlogs_reader/gcp_flowlogs_reader.py
+++ b/gcp_flowlogs_reader/gcp_flowlogs_reader.py
@@ -70,11 +70,9 @@ def page_helper(logging_client, wait_time=1.0, **kwargs):
         kwargs['page_token'] = None
         while True:
             try:
-                entry_num = 0
                 iterator = logging_client.list_entries(**kwargs)
                 for entry in iterator:
-                    token = _extract_page_token(iterator)
-                    kwargs['page_token'] = token
+                    kwargs['page_token'] = _extract_page_token(iterator)
                     yield entry
                 break
             except TooManyRequests:
@@ -245,7 +243,7 @@ class Reader:
         logging_client=None,
         service_account_json=None,
         service_account_info=None,
-        page_size=2,
+        page_size=1000,
         wait_time=1.0,
         **kwargs,
     ):

--- a/gcp_flowlogs_reader/gcp_flowlogs_reader.py
+++ b/gcp_flowlogs_reader/gcp_flowlogs_reader.py
@@ -31,8 +31,12 @@ BASE_LOG_NAME = 'projects/{}/logs/compute.googleapis.com%2Fvpc_flows'
 def _extract_page_token(iterator):
     """Extract the current page token from a v3 list_entries generator.
 
-    Reaches into generator frame locals to read the page token from the
-    underlying pager. Supports both gRPC and HTTP transport paths.
+    google-cloud-logging 3.0+ replaced the HTTPIterator (which had a
+    public next_page_token) with a plain generator that hides pagination
+    state.  We need the token to resume after 429s, so we reach into
+    gi_frame.f_locals to read it from the SDK's internal gRPC pager
+    (log_iter) or HTTP pager (page_iter).  Fragile but least-bad;
+    silently returns None if SDK internals change.
     """
     try:
         frame = iterator.gi_frame

--- a/gcp_flowlogs_reader/gcp_flowlogs_reader.py
+++ b/gcp_flowlogs_reader/gcp_flowlogs_reader.py
@@ -1,5 +1,7 @@
 from datetime import datetime, timedelta
 from ipaddress import ip_address, IPv4Address, IPv6Address
+import json
+from collections import OrderedDict
 from time import sleep
 from typing import NamedTuple, Optional, Union
 
@@ -26,9 +28,40 @@ except ImportError:
 from google.oauth2.service_account import Credentials
 
 BASE_LOG_NAME = 'projects/{}/logs/compute.googleapis.com%2Fvpc_flows'
+DEFAULT_DEDUPE_CACHE_SIZE = 100000
 
 
-def page_helper(logging_client, wait_time=1.0, **kwargs):
+def _entry_dedupe_key(entry):
+    payload = getattr(entry, 'payload', None)
+    if isinstance(payload, dict):
+        payload_repr = json.dumps(payload, sort_keys=True, default=str)
+    else:
+        payload_repr = str(payload)
+
+    log_name = getattr(entry, 'log_name', None)
+
+    return (
+        'payload_log_name',
+        payload_repr,
+        str(log_name),
+    )
+
+
+def _remember_seen(dedupe_cache, dedupe_key, max_dedupe_keys):
+    if dedupe_key in dedupe_cache:
+        dedupe_cache.move_to_end(dedupe_key)
+        return True
+
+    dedupe_cache[dedupe_key] = None
+    if len(dedupe_cache) > max_dedupe_keys:
+        dedupe_cache.popitem(last=False)
+    return False
+
+
+def page_helper(logging_client, wait_time=1.0, max_dedupe_keys=None, **kwargs):
+    max_dedupe_keys = max_dedupe_keys or DEFAULT_DEDUPE_CACHE_SIZE
+    dedupe_cache = OrderedDict()
+
     # handle google-cloud-logging >= 3.0
     if gcp_logging_version[0] == '3':
         # the project arg in google-cloud-logging >= 3.0 was changed to resource_names
@@ -42,6 +75,9 @@ def page_helper(logging_client, wait_time=1.0, **kwargs):
             try:
                 iterator = logging_client.list_entries(**kwargs)
                 for entry in iterator:
+                    dedupe_key = _entry_dedupe_key(entry)
+                    if _remember_seen(dedupe_cache, dedupe_key, max_dedupe_keys):
+                        continue
                     yield entry
                 return
             except TooManyRequests:

--- a/gcp_flowlogs_reader/gcp_flowlogs_reader.py
+++ b/gcp_flowlogs_reader/gcp_flowlogs_reader.py
@@ -38,10 +38,15 @@ def page_helper(logging_client, wait_time=1.0, **kwargs):
             ]
             del kwargs['projects']
         # google-cloud-logging >= 3.0 handles paging internally
-        iterator = logging_client.list_entries(**kwargs)
-        for entry in iterator:
-            yield entry
-        return
+        while True:
+            try:
+                iterator = logging_client.list_entries(**kwargs)
+                for entry in iterator:
+                    yield entry
+                return
+            except TooManyRequests:
+                sleep(wait_time)
+                pass
 
     # google-cloud-logging < 3.0 requires us to handle paging
     kwargs['page_token'] = None

--- a/gcp_flowlogs_reader/gcp_flowlogs_reader.py
+++ b/gcp_flowlogs_reader/gcp_flowlogs_reader.py
@@ -4,15 +4,22 @@ from time import sleep
 from typing import NamedTuple, Optional, Union
 
 from google.api_core.exceptions import (
+    DeadlineExceeded,
     Forbidden,
     GoogleAPIError,
+    InternalServerError,
     NotFound,
+    ServiceUnavailable,
     TooManyRequests,
 )
+from google.api_core.retry import Retry, if_exception_type
 from google.cloud.logging import (
     Client as LoggingClient,
     __version__ as gcp_logging_version,
 )
+from google.cloud.logging_v2 import _gapic
+from google.cloud.logging_v2.types import ListLogEntriesRequest
+from google.cloud.logging_v2.types import LogEntry
 
 try:
     from google.cloud.logging import StructEntry
@@ -27,8 +34,23 @@ from google.oauth2.service_account import Credentials
 
 BASE_LOG_NAME = 'projects/{}/logs/compute.googleapis.com%2Fvpc_flows'
 
+# Custom retry that includes TooManyRequests (429) in addition to the
+# default transient errors.  Applied per-page by the gapic pager so
+# each individual page fetch is retried with exponential backoff.
+DEFAULT_RETRY = Retry(
+    initial=1.0,
+    maximum=60.0,
+    multiplier=2.0,
+    predicate=if_exception_type(
+        TooManyRequests,
+        DeadlineExceeded,
+    ),
+    deadline=300.0,
+)
+
 
 def page_helper(logging_client, wait_time=1.0, **kwargs):
+    print(f"Fetching with filter: {kwargs.get('filter_')}")
     # handle google-cloud-logging >= 3.0
     if gcp_logging_version[0] == '3':
         # the project arg in google-cloud-logging >= 3.0 was changed to resource_names
@@ -37,22 +59,35 @@ def page_helper(logging_client, wait_time=1.0, **kwargs):
                 f'projects/{project}' for project in kwargs['projects']
             ]
             del kwargs['projects']
-        # google-cloud-logging >= 3.0 handles paging internally
-        yielded_count = 0
-        while True:
-            try:
-                iterator = logging_client.list_entries(**kwargs)
-                skip = yielded_count
-                for entry in iterator:
-                    if skip > 0:
-                        skip -= 1
-                        continue
-                    yield entry
-                    yielded_count += 1
-                return
-            except TooManyRequests:
-                sleep(wait_time)
-                pass
+
+        # Use the low-level gapic client so we can pass a custom Retry
+        # that handles 429s. The pager manages page_token automatically.
+        gapic_client = logging_client.logging_api._gapic_api
+
+        request = ListLogEntriesRequest(
+            resource_names=kwargs.get('resource_names', []),
+            filter=kwargs.get('filter_', ''),
+            order_by='timestamp asc',
+            page_size=kwargs.get('page_size', 0),
+        )
+
+        # The gapic pager applies retry to every page fetch (including the
+        # first).  On rate-limit (429) it backs off automatically.
+        pager = gapic_client.list_log_entries(
+            request=request,
+            retry=DEFAULT_RETRY,
+            timeout=DEFAULT_RETRY.deadline,
+        )
+
+        # Parse gapic LogEntry protos back into high-level StructEntry
+        # objects via the same bridge the high-level Client uses.
+        loggers = {}
+        for entry in pager:
+            log_entry_dict = _gapic._parse_log_entry(LogEntry.pb(entry))
+            yield _gapic.entry_from_resource(
+                log_entry_dict, logging_client, loggers=loggers
+            )
+        return
 
     # google-cloud-logging < 3.0 requires us to handle paging
     kwargs['page_token'] = None

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = gcp_flowlogs_reader
-version = 3.0.0
+version = 4.0.0
 license = Apache
 url = https://github.com/obsrvbl-oss/gcp-flowlogs-reader
 description = Reader for Google Cloud VPC Flow Logs

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,3 @@
 from setuptools import setup
 
-
 setup()

--- a/tests/test_gcp_flowlogs_reader.py
+++ b/tests/test_gcp_flowlogs_reader.py
@@ -28,7 +28,6 @@ from gcp_flowlogs_reader import (
     ResourceLabels,
 )
 from gcp_flowlogs_reader.gcp_flowlogs_reader import safe_tuple_from_dict
-from gcp_flowlogs_reader.gcp_flowlogs_reader import _entry_dedupe_key
 
 PREFIX = 'gcp_flowlogs_reader.gcp_flowlogs_reader.{}'.format
 SAMPLE_PAYLOADS = [
@@ -251,7 +250,7 @@ class V3PageHelperTests(TestCase):
 
     @patch(PREFIX('gcp_logging_version'), '3.0.0')
     @patch(PREFIX('sleep'), autospec=True)
-    def test_too_many_requests_mid_stream_no_duplicates(self, mock_sleep):
+    def test_too_many_requests_mid_stream_skips_already_yielded(self, mock_sleep):
         class FailingAfterOneEntry:
             def __iter__(self):
                 yield SAMPLE_ENTRIES[0]
@@ -264,7 +263,10 @@ class V3PageHelperTests(TestCase):
         ]
 
         iterator = page_helper(logging_client=mock_logging_client, projects=['proj1'])
-        self.assertEqual(list(iterator), SAMPLE_ENTRIES)
+        results = list(iterator)
+        # first call yields SAMPLE_ENTRIES[0], then TooManyRequests;
+        # retry replays all entries but skips the 1 already yielded
+        self.assertEqual(results, [SAMPLE_ENTRIES[0]] + SAMPLE_ENTRIES[1:])
 
         self.assertEqual(mock_logging_client.list_entries.call_count, 2)
         mock_sleep.assert_called_once_with(1.0)
@@ -910,49 +912,3 @@ class MainCLITests(TestCase):
             )
         self.assertEqual(len(output.getvalue().splitlines()), 5)
         self.assertIn(call().list_projects(), MockResourceManagerClient.mock_calls)
-
-
-class DedupeKeyTests(TestCase):
-    def test_uses_payload_and_log_name(self):
-        class Entry:
-            payload = {'a': 1}
-            log_name = 'projects/proj1/logs/compute.googleapis.com%2Fvpc_flows'
-
-        key = _entry_dedupe_key(Entry())
-        self.assertEqual(
-            key,
-            (
-                'payload_log_name',
-                '{"a": 1}',
-                'projects/proj1/logs/compute.googleapis.com%2Fvpc_flows',
-            ),
-        )
-
-    def test_fallback_to_string_none_when_log_name_missing(self):
-        class Entry:
-            payload = {'b': 2}
-
-        key = _entry_dedupe_key(Entry())
-        self.assertEqual(
-            key,
-            (
-                'payload_log_name',
-                '{"b": 2}',
-                'None',
-            ),
-        )
-
-    def test_non_dict_payload_uses_string_representation(self):
-        class Entry:
-            payload = 'raw-payload'
-            log_name = 'projects/proj2/logs/custom'
-
-        key = _entry_dedupe_key(Entry())
-        self.assertEqual(
-            key,
-            (
-                'payload_log_name',
-                'raw-payload',
-                'projects/proj2/logs/custom',
-            ),
-        )

--- a/tests/test_gcp_flowlogs_reader.py
+++ b/tests/test_gcp_flowlogs_reader.py
@@ -30,7 +30,6 @@ from gcp_flowlogs_reader import (
 from gcp_flowlogs_reader.gcp_flowlogs_reader import safe_tuple_from_dict
 from gcp_flowlogs_reader.gcp_flowlogs_reader import _entry_dedupe_key
 
-
 PREFIX = 'gcp_flowlogs_reader.gcp_flowlogs_reader.{}'.format
 SAMPLE_PAYLOADS = [
     {

--- a/tests/test_gcp_flowlogs_reader.py
+++ b/tests/test_gcp_flowlogs_reader.py
@@ -230,7 +230,8 @@ class V3PageHelperTests(TestCase):
         iterator = page_helper(logging_client=MockLoggingClient(), projects=['proj1'])
         self.assertEqual(list(iterator), SAMPLE_ENTRIES)
         MockLoggingClient.return_value.list_entries.assert_called_with(
-            resource_names=['projects/proj1']
+            resource_names=['projects/proj1'],
+            page_token=None,
         )
 
     @patch(PREFIX('gcp_logging_version'), '3.0.0')
@@ -250,25 +251,42 @@ class V3PageHelperTests(TestCase):
 
     @patch(PREFIX('gcp_logging_version'), '3.0.0')
     @patch(PREFIX('sleep'), autospec=True)
-    def test_too_many_requests_mid_stream_skips_already_yielded(self, mock_sleep):
+    def test_too_many_requests_mid_stream_resumes_with_page_token(self, mock_sleep):
+        """After a mid-stream 429, retry uses page_token to resume."""
+        saved_token = 'page-token-after-entry-0'
+
         class FailingAfterOneEntry:
             def __iter__(self):
                 yield SAMPLE_ENTRIES[0]
                 raise TooManyRequests('rate limited')
 
         mock_logging_client = MagicMock()
-        mock_logging_client.list_entries.side_effect = [
-            FailingAfterOneEntry(),
-            iter(SAMPLE_ENTRIES),
-        ]
 
-        iterator = page_helper(logging_client=mock_logging_client, projects=['proj1'])
-        results = list(iterator)
-        # first call yields SAMPLE_ENTRIES[0], then TooManyRequests;
-        # retry replays all entries but skips the 1 already yielded
-        self.assertEqual(results, [SAMPLE_ENTRIES[0]] + SAMPLE_ENTRIES[1:])
+        def list_entries_side_effect(**kwargs):
+            token = kwargs.get('page_token')
+            if token is None:
+                return FailingAfterOneEntry()
+            elif token == saved_token:
+                # Resume from where we left off
+                return iter(SAMPLE_ENTRIES[1:])
+            return iter([])
+
+        mock_logging_client.list_entries.side_effect = list_entries_side_effect
+
+        with patch(PREFIX('_extract_page_token'), return_value=saved_token):
+            iterator = page_helper(
+                logging_client=mock_logging_client, projects=['proj1']
+            )
+            results = list(iterator)
+
+        # First call yields SAMPLE_ENTRIES[0], then TooManyRequests;
+        # retry uses saved page_token and returns remaining entries
+        self.assertEqual(results, list(SAMPLE_ENTRIES))
 
         self.assertEqual(mock_logging_client.list_entries.call_count, 2)
+        # Verify the retry call used the page_token
+        retry_call_kwargs = mock_logging_client.list_entries.call_args_list[1][1]
+        self.assertEqual(retry_call_kwargs['page_token'], saved_token)
         mock_sleep.assert_called_once_with(1.0)
 
 

--- a/tests/test_gcp_flowlogs_reader.py
+++ b/tests/test_gcp_flowlogs_reader.py
@@ -6,7 +6,11 @@ from unittest import TestCase
 from unittest.mock import MagicMock, patch, call
 from tempfile import NamedTemporaryFile
 
-from gcp_flowlogs_reader.gcp_flowlogs_reader import BASE_LOG_NAME, page_helper
+from gcp_flowlogs_reader.gcp_flowlogs_reader import (
+    BASE_LOG_NAME,
+    page_helper,
+    _extract_page_token,
+)
 from google.api_core.exceptions import (
     GoogleAPIError,
     PermissionDenied,
@@ -930,3 +934,72 @@ class MainCLITests(TestCase):
             )
         self.assertEqual(len(output.getvalue().splitlines()), 5)
         self.assertIn(call().list_projects(), MockResourceManagerClient.mock_calls)
+
+
+class ExtractPageTokenTests(TestCase):
+    def test_returns_none_for_exhausted_generator(self):
+        """An exhausted generator has gi_frame=None."""
+
+        def gen():
+            yield 1
+
+        g = gen()
+        list(g)  # exhaust it
+        self.assertIsNone(_extract_page_token(g))
+
+    def test_grpc_path_extracts_token(self):
+        """Simulates the gRPC path with log_iter whose inner frame has 'self'."""
+        mock_pager = MagicMock()
+        mock_pager._response.next_page_token = 'token-abc'
+
+        # The inner generator must use 'self' as a local variable name
+        # so _extract_page_token finds it via inner_frame.f_locals['self']
+        def inner_gen():
+            self = mock_pager  # noqa: F841
+            yield 'entry'
+            yield 'entry2'
+
+        def outer_gen():
+            log_iter = inner_gen()
+            for item in log_iter:
+                yield item
+
+        g = outer_gen()
+        next(g)
+        result = _extract_page_token(g)
+        self.assertEqual(result, 'token-abc')
+
+    def test_grpc_path_returns_none_for_empty_token(self):
+        """gRPC path returns None when next_page_token is empty string."""
+        mock_pager = MagicMock()
+        mock_pager._response.next_page_token = ''
+
+        def inner_gen():
+            self = mock_pager  # noqa: F841
+            yield 'entry'
+            yield 'entry2'
+
+        def outer_gen():
+            log_iter = inner_gen()
+            for item in log_iter:
+                yield item
+
+        g = outer_gen()
+        next(g)
+        result = _extract_page_token(g)
+        self.assertIsNone(result)
+
+    def test_http_path_extracts_token(self):
+        """Simulates the HTTP path with page_iter in frame locals."""
+        mock_page_iter = MagicMock()
+        mock_page_iter.next_page_token = 'http-token-123'
+
+        def outer_gen():
+            page_iter = mock_page_iter  # noqa: F841
+            for i in range(3):
+                yield i
+
+        g = outer_gen()
+        next(g)
+        result = _extract_page_token(g)
+        self.assertEqual(result, 'http-token-123')

--- a/tests/test_gcp_flowlogs_reader.py
+++ b/tests/test_gcp_flowlogs_reader.py
@@ -7,7 +7,12 @@ from unittest.mock import MagicMock, patch, call
 from tempfile import NamedTemporaryFile
 
 from gcp_flowlogs_reader.gcp_flowlogs_reader import BASE_LOG_NAME, page_helper
-from google.api_core.exceptions import GoogleAPIError, PermissionDenied, NotFound
+from google.api_core.exceptions import (
+    GoogleAPIError,
+    PermissionDenied,
+    NotFound,
+    TooManyRequests,
+)
 from google.cloud.logging import Client
 from google.cloud.logging import StructEntry, Resource
 from google.oauth2.service_account import Credentials
@@ -23,6 +28,7 @@ from gcp_flowlogs_reader import (
     ResourceLabels,
 )
 from gcp_flowlogs_reader.gcp_flowlogs_reader import safe_tuple_from_dict
+from gcp_flowlogs_reader.gcp_flowlogs_reader import _entry_dedupe_key
 
 
 PREFIX = 'gcp_flowlogs_reader.gcp_flowlogs_reader.{}'.format
@@ -228,6 +234,41 @@ class V3PageHelperTests(TestCase):
         MockLoggingClient.return_value.list_entries.assert_called_with(
             resource_names=['projects/proj1']
         )
+
+    @patch(PREFIX('gcp_logging_version'), '3.0.0')
+    @patch(PREFIX('sleep'), autospec=True)
+    def test_too_many_requests_retry(self, mock_sleep):
+        mock_logging_client = MagicMock()
+        mock_logging_client.list_entries.side_effect = [
+            TooManyRequests('rate limited'),
+            iter(SAMPLE_ENTRIES),
+        ]
+
+        iterator = page_helper(logging_client=mock_logging_client, projects=['proj1'])
+        self.assertEqual(list(iterator), SAMPLE_ENTRIES)
+
+        self.assertEqual(mock_logging_client.list_entries.call_count, 2)
+        mock_sleep.assert_called_once_with(1.0)
+
+    @patch(PREFIX('gcp_logging_version'), '3.0.0')
+    @patch(PREFIX('sleep'), autospec=True)
+    def test_too_many_requests_mid_stream_no_duplicates(self, mock_sleep):
+        class FailingAfterOneEntry:
+            def __iter__(self):
+                yield SAMPLE_ENTRIES[0]
+                raise TooManyRequests('rate limited')
+
+        mock_logging_client = MagicMock()
+        mock_logging_client.list_entries.side_effect = [
+            FailingAfterOneEntry(),
+            iter(SAMPLE_ENTRIES),
+        ]
+
+        iterator = page_helper(logging_client=mock_logging_client, projects=['proj1'])
+        self.assertEqual(list(iterator), SAMPLE_ENTRIES)
+
+        self.assertEqual(mock_logging_client.list_entries.call_count, 2)
+        mock_sleep.assert_called_once_with(1.0)
 
 
 class FlowRecordTests(TestCase):
@@ -511,6 +552,25 @@ class ReaderTests(TestCase):
             projects=['yoyodyne-102010'],
             page_token=None,
         )
+
+    @patch(PREFIX('sleep'), autospec=True)
+    def test_iteration_retries_too_many_requests(self, mock_sleep, MockLoggingClient):
+        MockLoggingClient.return_value.project = 'yoyodyne-102010'
+        MockLoggingClient.return_value.list_entries.side_effect = [
+            TooManyRequests('rate limited'),
+            MockIterator(),
+        ]
+
+        earlier = datetime(2018, 4, 3, 9, 51, 22)
+        later = datetime(2018, 4, 3, 10, 51, 33)
+        reader = Reader(start_time=earlier, end_time=later, log_name='my_log')
+
+        actual = list(reader)
+        expected = [FlowRecord(x) for x in SAMPLE_ENTRIES]
+        self.assertEqual(actual, expected)
+
+        self.assertEqual(MockLoggingClient.return_value.list_entries.call_count, 2)
+        mock_sleep.assert_called_once_with(1.0)
 
     @patch(PREFIX('ResourceManagerClient'), autospec=True)
     @patch(PREFIX('Credentials'), autospec=True)
@@ -851,3 +911,49 @@ class MainCLITests(TestCase):
             )
         self.assertEqual(len(output.getvalue().splitlines()), 5)
         self.assertIn(call().list_projects(), MockResourceManagerClient.mock_calls)
+
+
+class DedupeKeyTests(TestCase):
+    def test_uses_payload_and_log_name(self):
+        class Entry:
+            payload = {'a': 1}
+            log_name = 'projects/proj1/logs/compute.googleapis.com%2Fvpc_flows'
+
+        key = _entry_dedupe_key(Entry())
+        self.assertEqual(
+            key,
+            (
+                'payload_log_name',
+                '{"a": 1}',
+                'projects/proj1/logs/compute.googleapis.com%2Fvpc_flows',
+            ),
+        )
+
+    def test_fallback_to_string_none_when_log_name_missing(self):
+        class Entry:
+            payload = {'b': 2}
+
+        key = _entry_dedupe_key(Entry())
+        self.assertEqual(
+            key,
+            (
+                'payload_log_name',
+                '{"b": 2}',
+                'None',
+            ),
+        )
+
+    def test_non_dict_payload_uses_string_representation(self):
+        class Entry:
+            payload = 'raw-payload'
+            log_name = 'projects/proj2/logs/custom'
+
+        key = _entry_dedupe_key(Entry())
+        self.assertEqual(
+            key,
+            (
+                'payload_log_name',
+                'raw-payload',
+                'projects/proj2/logs/custom',
+            ),
+        )


### PR DESCRIPTION
Handling `TooManyRequest` for v3.0.0 similar to the [pre3.0.0](https://github.com/obsrvbl-oss/gcp-flowlogs-reader/blob/main/gcp_flowlogs_reader/gcp_flowlogs_reader.py#L48-L57).

### Context

In google-cloud-logging < 3.0, `list_entries()` returned an Iterator with a public `next_page_token` and `.pages` property, helping to track pagination state and resume after `TooManyRequests` (429) errors. 

In 3.0+ the SDK replaced that with a plain Python generator that hides all pagination state internally and no public API exists to read the page token. Since large Cloud Logging queries regularly hit 429s, losing resume support would be a breaking change from older gcp-flowlogs-reader releases.

### Changes

To preserve resumability and not fail on `TooManyRequest`, this code peeks into the generator's frame locals `gi_frame.f_locals` and extract the token from the underlying pager. 
 - in the gRPC path, the attribute is `log_iter.self._response.next_page_token` 
 - the HTTP path, the attribute is `page_iter.next_page_token`

This is fragile as it depends on SDK-internal variable names, but it's the least-bad option. If a future SDK release changes these internals, the function silently returns None, losing resume but not crashing.

### Verification

[Test Script](https://github.com/user-attachments/files/25858318/test_integration.py)

<details>
<summary>Test in v1.15</summary>

> <img width="1005" height="424" alt="image" src="https://github.com/user-attachments/assets/c147c7d7-06b8-4025-8c19-8eec0cff74de" />

</details>

<details>
<summary>test in v3.13 without fix</summary>

> <img width="1008" height="270" alt="image" src="https://github.com/user-attachments/assets/40e43291-3906-48e1-9f4d-596529ade53d" />

> <img width="1013" height="75" alt="image" src="https://github.com/user-attachments/assets/94439675-7411-460f-b660-bb9e58a0517e" />


</details>

<details>
<summary>test in v3.13 with fix</summary>

> <img width="1009" height="458" alt="image" src="https://github.com/user-attachments/assets/0a35e9b3-4bca-4995-b37b-1f992fdda0d0" />

</details>